### PR TITLE
CASMPET-4342: Adding fixes for allowing ssl upsteam

### DIFF
--- a/kubernetes/cray-oauth2-proxy/templates/deployment.yaml
+++ b/kubernetes/cray-oauth2-proxy/templates/deployment.yaml
@@ -31,6 +31,9 @@ spec:
         - {{ . }}
         {{- end}}
         env:
+        # Allows go http proxy to use the certs in etc/tls as root certs
+        - name: SSL_CERT_DIR
+          value: '/etc/ssl:/etc/tls'
         # Holds cookie secret used to encrypt the cookie oauth2 proxy saves.
         - name: OAUTH2_PROXY_COOKIE_SECRET
           valueFrom: 

--- a/kubernetes/cray-oauth2-proxy/values.yaml
+++ b/kubernetes/cray-oauth2-proxy/values.yaml
@@ -18,7 +18,7 @@ oauth2ClientSecret: oauth2-proxy-client
 
 # The URL to which traffic is forwarded after authentication (and
 # authorization). This is expected to be the Istio ingress gateway.
-upstreamUrl: "http://istio-ingressgateway.istio-system.svc.cluster.local/"
+upstreamUrl: "https://istio-ingressgateway.istio-system.svc.cluster.local/"
 
 # The hostnames that oauth2-proxy will proxy. Hosts must be 
 # overridden with valid values, a single value here is used to ensure


### PR DESCRIPTION
### Summary and Scope

This updates the proxy to use a SSL upstream as needed to be secure.

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

### Issues and Related PRs

* Resolves CASMPET-4342

### Testing

Tested on:

* Virtual Shasta

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc)
Was a fresh Install tested? Y
Was an Upgrade tested?      Y
Was a Downgrade tested?   N.  If not, Why? Not needed this services is not in place yet.