### PR TITLE
CASMPET-4874: Create release/csm-1.1 for Oauth2-Proxy

### DIFF
--- a/kubernetes/cray-oauth2-proxy/templates/deployment.yaml
+++ b/kubernetes/cray-oauth2-proxy/templates/deployment.yaml
@@ -36,10 +36,7 @@ spec:
           value: '/etc/ssl:/etc/tls'
         # Holds cookie secret used to encrypt the cookie oauth2 proxy saves.
         - name: OAUTH2_PROXY_COOKIE_SECRET
-          valueFrom: 
-            secretKeyRef:
-              name: {{ .Values.oauth2ClientSecret }}
-              key: cookie-secret
+          value: lwLQpx7rj_XmU3MkUd3YGjQ= 
         - name: OAUTH2_PROXY_OIDC_ISSUER_URL
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
Commits:

- CASMPET-4874: Create release/csm-1.1 for Oauth2-Proxy

This change is needed because it moves the cookie secret from a secret to a hard coded value. This is needed to be able to use the current secrets that are generated by keycloak-setup which does not set up a cookie secret. This allows Oauth2-proxy to be swapped in for keycloak-gateway with only small changes in the customization.yaml for csm-1.1

