### PR TITLE
CASMPET-5131: Change the metallb address pool to customer-management

### DIFF
--- a/kubernetes/cray-oauth2-proxy/templates/service.yaml
+++ b/kubernetes/cray-oauth2-proxy/templates/service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
 {{ include "cray-oauth2-proxy.labels" . | indent 4 }}
   annotations:
-    metallb.universe.tf/address-pool: customer-access
+    metallb.universe.tf/address-pool: {{ .Values.metalLbAddressPool }}
     external-dns.alpha.kubernetes.io/hostname: {{ range $idx, $val := .Values.hosts }}{{ if gt $idx 0 }},{{ end }}{{ $val }}{{ end }}
 spec:
   type: LoadBalancer

--- a/kubernetes/cray-oauth2-proxy/values.yaml
+++ b/kubernetes/cray-oauth2-proxy/values.yaml
@@ -21,6 +21,9 @@ oauth2ClientSecret: oauth2-proxy-client
 # authorization). This is expected to be the Istio ingress gateway.
 upstreamUrl: "https://istio-ingressgateway.istio-system.svc.cluster.local/"
 
+# The address pool that will be used.
+metalLbAddressPool: customer-management
+
 # The hostnames that oauth2-proxy will proxy. Hosts must be 
 # overridden with valid values, a single value here is used to ensure
 # the chart builds successfully (e.g., the certificate chart requires


### PR DESCRIPTION
## Summary and Scope

The oauth2 metallb address pool needs to be changed to match the change in keycloak-gatekeeper.
This was seen in CASMPET-5129

This change is not backwards compatable

## Issues and Related PRs

* Resolves CASMPET-5131

## Testing

### Tested on:
  * Virtual Shasta

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? No
- Was upgrade tested? If not, why? Yes
- Was downgrade tested? If not, why? No this would not ever need to be downgraded


