### PR TITLE
CASMPET-5131: Change the metallb address pool to customer-management

### DIFF
--- a/kubernetes/cray-oauth2-proxy/Chart.yaml
+++ b/kubernetes/cray-oauth2-proxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "7.1.3"
 description: A Helm chart for Kubernetes
 name: cray-oauth2-proxy
-version: 0.1.0
+version: 0.1.1


### PR DESCRIPTION
Version bump to cray-oauth2-proxy 0.1.1. Only changes the metallb address pool to customer-managment. Increments version to 0.1.1 because it is a small change that needs new release but nothing large.