### PR TITLE
CASMPET-5154: Use Sealed Secret for cookie secret

### DIFF
--- a/kubernetes/cray-oauth2-proxy/templates/deployment.yaml
+++ b/kubernetes/cray-oauth2-proxy/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
         - name: OAUTH2_PROXY_COOKIE_SECRET
           valueFrom: 
             secretKeyRef:
-              name: {{ .Values.oauth2ClientSecret }}
+              name: {{ .Values.oauth2ProxySecret }}
               key: cookie-secret
         - name: OAUTH2_PROXY_OIDC_ISSUER_URL
           valueFrom:

--- a/kubernetes/cray-oauth2-proxy/templates/sealedsecrets.yaml
+++ b/kubernetes/cray-oauth2-proxy/templates/sealedsecrets.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.sealedSecrets -}}
+{{- range $val := .Values.sealedSecrets }}
+{{- if $val.kind }}
+{{- if eq $val.kind "SealedSecret" }}
+---
+{{ toYaml $val }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/kubernetes/cray-oauth2-proxy/values.yaml
+++ b/kubernetes/cray-oauth2-proxy/values.yaml
@@ -13,8 +13,12 @@ nameOverride: ""
 fullnameOverride: ""
 priorityClassName: csm-high-priority-service
 
+# The OAuth2-Proxy Secret includes the cookie-secret. This is created
+# by a Sealed Secret.
+oauth2ProxySecret: cray-oauth2-proxy
+
 # The Keycloak client secret includes the client ID, client secret, and
-# discovery URL. It is configured as part of keycloak_deploy role.
+# discovery URL. It is created by the keycloak-setup tool.
 oauth2ClientSecret: oauth2-proxy-client
 
 # The URL to which traffic is forwarded after authentication (and
@@ -53,3 +57,6 @@ arguments:
 - --tls-cert-file=/etc/tls/tls.crt
 - --tls-key-file=/etc/tls/tls.key
 - --provider-ca-file=/etc/tls/ca.crt
+
+# A list of sealedSecrets passed in to be deployed.
+sealedSecrets: []


### PR DESCRIPTION
### Summary and Scope

Puts the changes in place in values.yaml and the template to use
a Sealed Secret specified in customizations.yaml.

This will use the normal methods of creating and modifying the
random string.

This will be used to create a cray-oauth2-proxy Secret that
contains the random string used for the cookie secret.

IS THIS A NEW FEATURE OR CRITICAL BUG FIX? New feature.

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? N/A

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: Copyright 2014-2021 Hewlett Packard Enterprise Development LP    ? N/A

### Issues and Related PRs

LIST AND CHARACTERIZE RELATIONSHIP TO JIRA ISSUES AND OTHER PULL REQUESTS. BE SURE LIST DEPENDENCIES.

* Resolves CASMPET-5154

### Testing

Tested on:

* Virtual Shasta

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) N
Was a fresh Install tested? Y
Was an Upgrade tested?      N   If not, Why? This chart isn't being installed yet.
Was a Downgrade tested?     N.  If not, Why? ^
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

WHAT WAS THE EXTENT OF TESTING PERFORMED? MANUAL VERSUS AUTOMATED TESTS (UNIT/SMOKE/OTHER) 
HOW WERE CHANGES VERIFIED TO BE SUCCESSFUL?

Deployed this to virtual shasta with necessary changes to customizations.yaml. Made sure that the Secret was created and looked correct. Accessed Kiali through the oauth2-gatekeeper.

### Risks and Mitigations

IF APPLICABLE, HAS A SECURITY AUDIT (via SNYK OR OTHERWISE) BEEN RUN? N
ARE THERE KNOWN ISSUES WITH THESE CHANGES? N
ANY OTHER SPECIAL CONSIDERATIONS? N

Requires: None
