### PR TITLE
CASMPET-5154: Bump chart version to prep for release

### DIFF
--- a/kubernetes/cray-oauth2-proxy/Chart.yaml
+++ b/kubernetes/cray-oauth2-proxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "7.1.3"
 description: A Helm chart for Kubernetes
 name: cray-oauth2-proxy
-version: 0.1.1
+version: 0.2.0


### PR DESCRIPTION
This chart has been released before but it's not included in the
platform manifest so it doesn't matter what the version is just
needs to be different so I can releaes it again.

