### PR TITLE
CASMPET-5155: Calculate certificate name

### DIFF
--- a/kubernetes/cray-oauth2-proxy/Chart.yaml
+++ b/kubernetes/cray-oauth2-proxy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "7.1.3"
 description: A Helm chart for Kubernetes
 name: cray-oauth2-proxy
-version: 0.2.0
+version: 0.3.0

--- a/kubernetes/cray-oauth2-proxy/templates/certificate.yaml
+++ b/kubernetes/cray-oauth2-proxy/templates/certificate.yaml
@@ -1,7 +1,7 @@
 apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
-  name: oauth2-proxy
+  name: {{ template "cray-oauth2-proxy.fullname" . }}
 spec:
   secretName: {{ .Values.certificateSecretName }}
   issuerRef:


### PR DESCRIPTION
The hardcoded certificate name made it such that there could only
be 1 instance of the cray-oauth2-proxy chart deployed. This change
makes it so that multiple instances of the chart can be deployed.

This chart hasn't been included in the CSM manifest so I included
the version change in this change.
