### PR TITLE
CASMPET-5155: Chart to create separate oauth2-proxy instances for Bi-CAN

### DIFF
--- a/kubernetes/cray-oauth2-proxies/.gitignore
+++ b/kubernetes/cray-oauth2-proxies/.gitignore
@@ -1,0 +1,2 @@
+charts
+Chart.lock

--- a/kubernetes/cray-oauth2-proxies/Chart.yaml
+++ b/kubernetes/cray-oauth2-proxies/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+description: Deploys the different instances of cray-oauth2-proxy that are needed on a Cray system.
+name: cray-oauth2-proxies
+version: 0.1.0
+dependencies:
+- name: cray-oauth2-proxy
+  version: "0.3.0"
+  repository: "https://artifactory.algol60.net/artifactory/csm-helm-charts"
+  alias: customer-management
+- name: cray-oauth2-proxy
+  version: "0.3.0"
+  repository: "https://artifactory.algol60.net/artifactory/csm-helm-charts"
+  alias: customer-access
+- name: cray-oauth2-proxy
+  version: "0.3.0"
+  repository: "https://artifactory.algol60.net/artifactory/csm-helm-charts"
+  alias: customer-high-speed

--- a/kubernetes/cray-oauth2-proxies/values.yaml
+++ b/kubernetes/cray-oauth2-proxies/values.yaml
@@ -1,0 +1,18 @@
+
+customer-management:
+  metalLbAddressPool: customer-management
+  certificateSecretName: cray-oauth2-proxies-customer-management
+  oauth2ProxySecret: cray-oauth2-proxy-customer-management
+  oauth2ClientSecret: oauth2-proxy-customer-management-client
+
+customer-access:
+  metalLbAddressPool: customer-access
+  certificateSecretName: cray-oauth2-proxies-customer-access
+  oauth2ProxySecret: cray-oauth2-proxy-customer-access
+  oauth2ClientSecret: oauth2-proxy-customer-access-client
+
+customer-high-speed:
+  metalLbAddressPool: customer-high-speed
+  certificateSecretName: cray-oauth2-proxies-customer-high-speed
+  oauth2ProxySecret: cray-oauth2-proxy-customer-high-speed
+  oauth2ClientSecret: oauth2-proxy-customer-high-speed-client


### PR DESCRIPTION
### Summary and Scope

This change adds a new chart that deploys multiple instances of the
cray-oauth2-proxy chart.

NOTE: You might wonder why this can't be done in the loftsman
manifest using unique `releaseName` values. I tried this and it
didn't work. The other tools (e.g., manifestgen) ignore that field
and only use the name, so this loftsman feature is not usable.

With bifurcated CAN we need oauth2-proxy instances listening on
different interfaces. This is done by setting the
`metallb.universe.tf/address-pool` on the services
(metalLbAddressPool in values.yaml). Also the oauth2-proxy
instances are proxying different sets of apps on different
hostnames.

keycloak-setup will create the oauth2ClientSecrets.

The oauth2ProxySecrets will be created using Sealed Secrets, this
is in the customizations.yaml.

The hosts for each cray-oauth2-proxy instance will be set in
customizations.yaml.

IS THIS A NEW FEATURE OR CRITICAL BUG FIX? New feature

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? N/A

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: Copyright 2014-2021 Hewlett Packard Enterprise Development LP    ? N/A

### Issues and Related PRs

* Resolves CASMPET-5155

### Testing

Tested on:

* Virtual Shasta

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) N
Was a fresh Install tested? Y
Was an Upgrade tested?      N   If not, Why? This is a new chart, nothing to upgrade/downgrade
Was a Downgrade tested?     N.  If not, Why? ^
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

WHAT WAS THE EXTENT OF TESTING PERFORMED? MANUAL VERSUS AUTOMATED TESTS (UNIT/SMOKE/OTHER) Manual
HOW WERE CHANGES VERIFIED TO BE SUCCESSFUL?

Deployed this to vshasta, made sure that the instances were created and had the correct metallb setting and external hostname settings. I tried logging into kiali-istio through an oauth2-proxy and it worked.

### Risks and Mitigations

IF APPLICABLE, HAS A SECURITY AUDIT (via SNYK OR OTHERWISE) BEEN RUN? N
ARE THERE KNOWN ISSUES WITH THESE CHANGES? N
ANY OTHER SPECIAL CONSIDERATIONS? N

Requires: None
