### PR TITLE
CASMPET-4277: Update build for new oauth2-proxies chart

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -14,7 +14,10 @@ pipeline {
         NAME = "cray-oauth2-proxy"
         DESCRIPTION = "Deploys the Oauth2 Proxy ingress to the Cray system."
         IS_STABLE = getBuildIsStable()
-        CHART_VERSION = getChartVersion(name: env.NAME, isStable: env.IS_STABLE)
+        CHART_NAME_1 = "cray-oauth2-proxy"
+        CHART_NAME_2 = "cray-oauth2-proxies"
+        CHART_VERSION_1 = getChartVersion(name: env.CHART_NAME_1, isStable: env.IS_STABLE)
+        CHART_VERSION_2 = getChartVersion(name: env.CHART_NAME_2, isStable: env.IS_STABLE)
     }
 
     stages {
@@ -22,7 +25,7 @@ pipeline {
             parallel {
                 stage('Chart') {
                     steps {
-                        sh "make chart"
+                        sh "make charts"
                     }
                 }
             }

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,32 @@
-NAME ?= cray-oauth2-proxy
+CHART_NAME_1 ?= cray-oauth2-proxy
+CHART_NAME_2 ?= cray-oauth2-proxies
 CHART_PATH ?= kubernetes
-CHART_VERSION ?= local
+CHART_VERSION_1 ?= local
+CHART_VERSION_2 ?= local
 
 HELM_UNITTEST_IMAGE ?= quintush/helm-unittest:3.3.0-0.2.5
 
-all : chart
-chart: chart_setup chart_package chart_test
 
+all : charts
+charts: chart_setup chart_packages chart_tests
+chart_packages: chart_package_1 chart_package_2
+chart_tests: chart_test_1 chart_test_2
 
 chart_setup:
 		mkdir -p ${CHART_PATH}/.packaged
 
-chart_package:
-		helm dep up ${CHART_PATH}/${NAME}
-		helm package ${CHART_PATH}/${NAME} -d ${CHART_PATH}/.packaged --version ${CHART_VERSION}
+chart_package_1:
+		helm dep up ${CHART_PATH}/${CHART_NAME_1}
+		helm package ${CHART_PATH}/${CHART_NAME_1} -d ${CHART_PATH}/.packaged --version ${CHART_VERSION_1}
 
-chart_test:
-		helm lint "${CHART_PATH}/${NAME}"
-		docker run --rm -v ${PWD}/${CHART_PATH}:/apps ${HELM_UNITTEST_IMAGE} -3 ${NAME}
+chart_test_1:
+		helm lint "${CHART_PATH}/${CHART_NAME_1}"
+		docker run --rm -v ${PWD}/${CHART_PATH}:/apps ${HELM_UNITTEST_IMAGE} -3 ${CHART_NAME_1}
+
+chart_package_2:
+		helm dep up ${CHART_PATH}/${CHART_NAME_2}
+		helm package ${CHART_PATH}/${CHART_NAME_2} -d ${CHART_PATH}/.packaged --version ${CHART_VERSION_2}
+
+chart_test_2:
+		helm lint "${CHART_PATH}/${CHART_NAME_2}"
+		docker run --rm -v ${PWD}/${CHART_PATH}:/apps ${HELM_UNITTEST_IMAGE} -3 ${CHART_NAME_2}


### PR DESCRIPTION
Updates the Jenkinsfile and Makefile to actually build and public
the new cray-oauth2-proxies chart.
