### PR TITLE
CASMPET-5159: Update oauth2-proxy to 7.2.0

### DIFF
--- a/kubernetes/cray-oauth2-proxy/Chart.yaml
+++ b/kubernetes/cray-oauth2-proxy/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "7.1.3"
+appVersion: "7.2.0"
 description: A Helm chart for Kubernetes
 name: cray-oauth2-proxy
-version: 0.3.0
+version: 0.3.1

--- a/kubernetes/cray-oauth2-proxy/values.yaml
+++ b/kubernetes/cray-oauth2-proxy/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: quay.io/oauth2-proxy/oauth2-proxy
-  tag: v7.1.3
+  tag: v7.2.0
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
### Summary and Scope

The 7.1.3 image has several high and critical vulnerabilities.
The 7.2.0 image has not high and critical vulnerabilities.
So switch to the 7.2.0 image.

The chart version is updated in this commit because this chart
hasn't been shipped yet, it's not in the CSM manifest.

IS THIS A NEW FEATURE OR CRITICAL BUG FIX? bug fix

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? Y

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: Copyright 2014-2021 Hewlett Packard Enterprise Development LP    ? N/A

### Issues and Related PRs

* Resolves CASMPET-5159

### Testing

Tested on:

* Virtual Shasta

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) N
Was a fresh Install tested? Y
Was an Upgrade tested?      N   If not, Why? This chart isn't deployed to systems yet.
Was a Downgrade tested?     N.  If not, Why?This chart isn't deployed to systems yet.
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

WHAT WAS THE EXTENT OF TESTING PERFORMED? MANUAL VERSUS AUTOMATED TESTS (UNIT/SMOKE/OTHER) manual
HOW WERE CHANGES VERIFIED TO BE SUCCESSFUL?

Deployed this new version and made sure I could get to kiali through oauth2-proxy.

### Risks and Mitigations

IF APPLICABLE, HAS A SECURITY AUDIT (via SNYK OR OTHERWISE) BEEN RUN? N
ARE THERE KNOWN ISSUES WITH THESE CHANGES? N
ANY OTHER SPECIAL CONSIDERATIONS? N

Requires: None
