### PR TITLE
CASMPET-5169: Update cray-oauth2-proxy version pulled in to 0.3.1

### DIFF
--- a/kubernetes/cray-oauth2-proxies/Chart.yaml
+++ b/kubernetes/cray-oauth2-proxies/Chart.yaml
@@ -1,17 +1,17 @@
 apiVersion: v2
 description: Deploys the different instances of cray-oauth2-proxy that are needed on a Cray system.
 name: cray-oauth2-proxies
-version: 0.1.0
+version: 0.1.1
 dependencies:
 - name: cray-oauth2-proxy
-  version: "0.3.0"
+  version: "0.3.1"
   repository: "https://artifactory.algol60.net/artifactory/csm-helm-charts"
   alias: customer-management
 - name: cray-oauth2-proxy
-  version: "0.3.0"
+  version: "0.3.1"
   repository: "https://artifactory.algol60.net/artifactory/csm-helm-charts"
   alias: customer-access
 - name: cray-oauth2-proxy
-  version: "0.3.0"
+  version: "0.3.1"
   repository: "https://artifactory.algol60.net/artifactory/csm-helm-charts"
   alias: customer-high-speed


### PR DESCRIPTION
### Summary and Scope

The cray-oauth2-proxy chart was recently updated to 0.3.1 to update
the oauth2-proxy image to v7.2.0, this pulls that change into
the cray-oauth2-proxies chart.

IS THIS A NEW FEATURE OR CRITICAL BUG FIX? bug fix

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES? N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? Y

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: Copyright 2014-2021 Hewlett Packard Enterprise Development LP    ? N/A

### Issues and Related PRs

* Resolves CASMPET-5169

### Testing

Tested on:

* Virtual Shasta

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) N
Was a fresh Install tested? Y
Was an Upgrade tested?      N   If not, Why? These charts haven't been included in CSM manifest yet.
Was a Downgrade tested?     N.  If not, Why? ^
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

WHAT WAS THE EXTENT OF TESTING PERFORMED? MANUAL VERSUS AUTOMATED TESTS (UNIT/SMOKE/OTHER) manual
HOW WERE CHANGES VERIFIED TO BE SUCCESSFUL?

This is just updating the cray-oauth2-proxy subchart version so if this builds it worked. I already tested the cray-oauth2-proxy change.

### Risks and Mitigations

IF APPLICABLE, HAS A SECURITY AUDIT (via SNYK OR OTHERWISE) BEEN RUN? N
ARE THERE KNOWN ISSUES WITH THESE CHANGES? N
ANY OTHER SPECIAL CONSIDERATIONS? N

Requires: None
