### PR TITLE
CASMPET-5534: switch to CSM built oauth2-proxy image

### DIFF
--- a/kubernetes/cray-oauth2-proxy/Chart.yaml
+++ b/kubernetes/cray-oauth2-proxy/Chart.yaml
@@ -1,5 +1,28 @@
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 apiVersion: v1
 appVersion: "7.2.1"
 description: A Helm chart for Kubernetes
 name: cray-oauth2-proxy
-version: 0.3.2
+version: 0.4.0

--- a/kubernetes/cray-oauth2-proxy/values.yaml
+++ b/kubernetes/cray-oauth2-proxy/values.yaml
@@ -1,3 +1,26 @@
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 # Default values for cray-oauth2.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
@@ -5,7 +28,7 @@
 replicaCount: 1
 
 image:
-  repository: quay.io/oauth2-proxy/oauth2-proxy
+  repository: artifactory.algol60.net/csm-docker/stable/quay.io/oauth2-proxy/oauth2-proxy
   tag: v7.2.1
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary and Scope

The original chart was using the oauth2-proxy image from upstream. This PR changes the cray-oauth2-proxy chart to use CSM build image. The chart minor version was bumped from 0.3.2 to 0.4.0.

## Issues and Related PRs

* Resolves [CASMPET-5534]

## Testing

### Tested on:

  * `wasp`

### Test description:

Deployed the new helm chart, and verified the following test script still PASS as it uses oauth2-proxy:

tests/install/livecd/scripts/monitoring_check.sh

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

