### PR TITLE
CASMPET-5697: upgrade oauth2-proxy to v7.3.0

### DIFF
--- a/kubernetes/cray-oauth2-proxy/Chart.yaml
+++ b/kubernetes/cray-oauth2-proxy/Chart.yaml
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 apiVersion: v1
-appVersion: "7.2.1"
+appVersion: "7.3.0"
 description: A Helm chart for Kubernetes
 name: cray-oauth2-proxy
-version: 0.4.0
+version: 0.5.0

--- a/kubernetes/cray-oauth2-proxy/values.yaml
+++ b/kubernetes/cray-oauth2-proxy/values.yaml
@@ -29,7 +29,7 @@ replicaCount: 1
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/quay.io/oauth2-proxy/oauth2-proxy
-  tag: v7.2.1
+  tag: v7.3.0
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
## Summary and Scope

Use latest oauth2-proxy v7.3.0 release for CVE remediation. The cray-oauth2-proxy chart minor version was bumped.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Partially Resolves [CASMPET-5697](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5697)
* Change will also be needed in `<insert branch name here>`
* Future work required by [CASMPET-5697](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5697)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

To be tested in a subsequent chart change to pick up the newly built cray-oauth2-proxy chart.

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

