### PR TITLE
CASMPET-6664: Update upstreamURL for customer-management

### DIFF
--- a/kubernetes/cray-oauth2-proxies/Chart.yaml
+++ b/kubernetes/cray-oauth2-proxies/Chart.yaml
@@ -24,7 +24,7 @@
 apiVersion: v2
 description: Deploys the different instances of cray-oauth2-proxy that are needed on a Cray system.
 name: cray-oauth2-proxies
-version: 0.3.0
+version: 0.3.1
 dependencies:
 - name: cray-oauth2-proxy
   version: "0.5.0"

--- a/kubernetes/cray-oauth2-proxies/values.yaml
+++ b/kubernetes/cray-oauth2-proxies/values.yaml
@@ -4,6 +4,7 @@ customer-management:
   certificateSecretName: cray-oauth2-proxies-customer-management
   oauth2ProxySecret: cray-oauth2-proxy-customer-management
   oauth2ClientSecret: oauth2-proxy-customer-management-client
+  upstreamUrl: "https://istio-ingressgateway-cmn.istio-system.svc.cluster.local/"
 
 customer-access:
   metalLbAddressPool: customer-access


### PR DESCRIPTION
## Summary and Scope

This update the upstream url for the customer management proxy to allow for a disconnection from the nmn gateway for all cmn traffic.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6664](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6664)
* Additional changes needed in [CASMPET-6664](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6664)

## Testing

### Tested on:

  * drax
  
### Test description:

Tested by manually updating the URL and discovered there was also a need for a customization change to allow for a different upstream url with a updated certificate

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?y
- Were continuous integration tests run? If not, why?y
- Was upgrade tested? If not, why?y
- Was downgrade tested? If not, why?y
- Were new tests (or test issues/Jiras) created for this change?y

## Risks and Mitigations

Risk in depending on what is installed on system and where in the upgrade process the install is in to allow for updated certificates and updated istio


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

