### PR TITLE
CASMPET-6904-update-cert-api update cert manager api version

### DIFF
--- a/kubernetes/cray-oauth2-proxies/Chart.yaml
+++ b/kubernetes/cray-oauth2-proxies/Chart.yaml
@@ -24,17 +24,17 @@
 apiVersion: v2
 description: Deploys the different instances of cray-oauth2-proxy that are needed on a Cray system.
 name: cray-oauth2-proxies
-version: 0.4.0
+version: 0.3.1
 dependencies:
 - name: cray-oauth2-proxy
-  version: "0.6.0"
+  version: "0.5.0"
   repository: "https://artifactory.algol60.net/artifactory/csm-helm-charts"
   alias: customer-management
 - name: cray-oauth2-proxy
-  version: "0.6.0"
+  version: "0.5.0"
   repository: "https://artifactory.algol60.net/artifactory/csm-helm-charts"
   alias: customer-access
 - name: cray-oauth2-proxy
-  version: "0.6.0"
+  version: "0.5.0"
   repository: "https://artifactory.algol60.net/artifactory/csm-helm-charts"
   alias: customer-high-speed

--- a/kubernetes/cray-oauth2-proxies/Chart.yaml
+++ b/kubernetes/cray-oauth2-proxies/Chart.yaml
@@ -24,17 +24,17 @@
 apiVersion: v2
 description: Deploys the different instances of cray-oauth2-proxy that are needed on a Cray system.
 name: cray-oauth2-proxies
-version: 0.3.1
+version: 0.4.0
 dependencies:
 - name: cray-oauth2-proxy
-  version: "0.5.0"
+  version: "0.6.0"
   repository: "https://artifactory.algol60.net/artifactory/csm-helm-charts"
   alias: customer-management
 - name: cray-oauth2-proxy
-  version: "0.5.0"
+  version: "0.6.0"
   repository: "https://artifactory.algol60.net/artifactory/csm-helm-charts"
   alias: customer-access
 - name: cray-oauth2-proxy
-  version: "0.5.0"
+  version: "0.6.0"
   repository: "https://artifactory.algol60.net/artifactory/csm-helm-charts"
   alias: customer-high-speed

--- a/kubernetes/cray-oauth2-proxy/Chart.yaml
+++ b/kubernetes/cray-oauth2-proxy/Chart.yaml
@@ -25,4 +25,4 @@ apiVersion: v1
 appVersion: "7.3.0"
 description: A Helm chart for Kubernetes
 name: cray-oauth2-proxy
-version: 0.5.0
+version: 0.6.0

--- a/kubernetes/cray-oauth2-proxy/templates/certificate.yaml
+++ b/kubernetes/cray-oauth2-proxy/templates/certificate.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ template "cray-oauth2-proxy.fullname" . }}


### PR DESCRIPTION
## Summary and Scope

Update cert-manager api version from v1alpha2 to v1. This is necessary for the cert-manager upgrade to v1.12.9 that is happening in CSM 1.6.

## Issues and Related PRs

* Relates to [CASMPET-6904](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6904)

## Testing

### Tested on:

  * Beau

### Test description:

Upgraded the cray-oauth2-proxies chart.

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

