### PR TITLE
CASMPET-7383: disable TLS1.2 for security

### DIFF
--- a/kubernetes/cray-oauth2-proxy/Chart.yaml
+++ b/kubernetes/cray-oauth2-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -25,4 +25,4 @@ apiVersion: v1
 appVersion: "7.3.0"
 description: A Helm chart for Kubernetes
 name: cray-oauth2-proxy
-version: 0.6.0
+version: 0.6.1

--- a/kubernetes/cray-oauth2-proxy/values.yaml
+++ b/kubernetes/cray-oauth2-proxy/values.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -77,6 +77,7 @@ arguments:
 # Workaround to get accounts without emails able to authenticate
 - --oidc-email-claim=sub
 - --email-domain=*
+- --tls-min-version=TLS1.3
 - --tls-cert-file=/etc/tls/tls.crt
 - --tls-key-file=/etc/tls/tls.key
 - --provider-ca-file=/etc/tls/ca.crt


### PR DESCRIPTION
## Summary and Scope

Due to a vulnerability associated with using the 3DES cipher in TLS 1.2 in the "Sweet32" attack, one customer requested that we disable TLS 1.2 in oauth2 proxies.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-7383](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7383)
* Change will also be needed in `release/csm-1.5`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

